### PR TITLE
Add object console extensions functionality

### DIFF
--- a/src/.net/Tenjin.Tests/ExtensionsTests/ObjectExtensionsTests.cs
+++ b/src/.net/Tenjin.Tests/ExtensionsTests/ObjectExtensionsTests.cs
@@ -1,12 +1,20 @@
-﻿using NUnit.Framework;
+﻿using System;
+using System.Globalization;
+using System.Text;
+using NUnit.Framework;
 using Tenjin.Extensions;
 using Tenjin.Tests.Enums;
+using Tenjin.Tests.Models.Console;
+using Tenjin.Tests.Services;
 
 namespace Tenjin.Tests.ExtensionsTests
 {
     [TestFixture]
     public class ObjectExtensionsTests
     {
+        private const string DateTimeWriteLineInputFormat = "yyyy-MM-dd";
+        private const string DateTimeWriteLineOutputFormat = "dd--MM--yyyy";
+
         [TestCase(null, "")]
         [TestCase("", null)]
         [TestCase(null, 1)]
@@ -1298,6 +1306,1810 @@ namespace Tenjin.Tests.ExtensionsTests
             object?[] objects)
         {
             Assert.IsTrue(root.DoesNotEqualAll(objects));
+        }
+
+        [TestCase(null)]
+        public void WriteLine_WhenWritingFromANullObject_LogsAnEmptyStringToTheConsole(object? root)
+        {
+            AssertWriteLine(root, string.Empty);
+        }
+
+        [TestCase(null)]
+        public void Write_WhenWritingFromANullObject_LogsAnEmptyStringToTheConsole(object? root)
+        {
+            AssertWrite(root, string.Empty);
+        }
+
+        [TestCase(null, null)]
+        [TestCase(null, "-")]
+        [TestCase(null, "++")]
+        [TestCase(null, "___")]
+        public void WriteHeading_WhenWritingFromANullObject_LogsAnEmptyStringToTheConsole(
+            object? root, 
+            string? headingUnderline)
+        {
+            AssertWriteHeading(root, string.Empty, headingUnderline);
+        }
+
+        [TestCase(null, 0)]
+        [TestCase(null, 1)]
+        [TestCase(null, 2)]
+        [TestCase(null, 3)]
+        [TestCase(null, 4)]
+        public void WriteLines_WhenWritingFromANullObject_LogsEmptyLinesToTheConsole(
+            object? root,
+            int numberOfLineAppends)
+        {
+            AssertWriteLines(root, numberOfLineAppends);
+        }
+
+        [TestCase(null, null, 0)]
+        [TestCase(null, null, 1)]
+        [TestCase(null, null, 2)]
+        [TestCase(null, null, 3)]
+        [TestCase(null, null, 4)]
+        [TestCase(null, "-", 0)]
+        [TestCase(null, "-", 1)]
+        [TestCase(null, "-", 2)]
+        [TestCase(null, "-", 3)]
+        [TestCase(null, "-", 4)]
+        [TestCase(null, "++", 0)]
+        [TestCase(null, "++", 1)]
+        [TestCase(null, "++", 2)]
+        [TestCase(null, "++", 3)]
+        [TestCase(null, "++", 4)]
+        [TestCase(null, "___", 0)]
+        [TestCase(null, "___", 1)]
+        [TestCase(null, "___", 2)]
+        [TestCase(null, "___", 3)]
+        [TestCase(null, "___", 4)]
+        public void WriteHeading_WhenWritingFromANullObject_LogsEmptyLinesToTheConsole(
+            object? root,
+            string? headingUnderline,
+            int numberOfLineAppends)
+        {
+            AssertWriteHeadingWithLineAppends(root, string.Empty, headingUnderline, numberOfLineAppends);
+        }
+
+        [TestCase("Test a string", "Test a string")]
+        [TestCase(1, "1")]
+        [TestCase(true, "True")]
+        [TestCase(false, "False")]
+        public void WriteLine_WhenWritingFromANonNullObject_LogsTheExpectedValueToTheConsole(object root, string expectedValue)
+        {
+            AssertWriteLine(root, expectedValue);
+        }
+
+        [TestCase("Test a string", "Test a string", 0)]
+        [TestCase(1, "1", 1)]
+        [TestCase(true, "True", 2)]
+        [TestCase(false, "False", 3)]
+        public void WriteLine_WhenWritingFromANonNullObjectWithLineAppends_LogsTheExpectedValueToTheConsole(
+            object root, 
+            string expectedValue,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithLineAppends(root, expectedValue, numberOfLineAppends);
+        }
+
+        [TestCase("Test a string", "Test a string", null)]
+        [TestCase(1, "1", null)]
+        [TestCase(true, "True", null)]
+        [TestCase(false, "False", null)]
+        [TestCase("Test a string", "Test a string", "-")]
+        [TestCase(1, "1", "-")]
+        [TestCase(true, "True", "-")]
+        [TestCase(false, "False", "-")]
+        [TestCase("Test a string", "Test a string", "++")]
+        [TestCase(1, "1", "++")]
+        [TestCase(true, "True", "++")]
+        [TestCase(false, "False", "++")]
+        [TestCase("Test a string", "Test a string", "___")] 
+        [TestCase(1, "1", "___")]
+        [TestCase(true, "True", "___")]
+        [TestCase(false, "False", "___")]
+        public void WriteHeading_WhenWritingFromANonNullObject_LogsTheExpectedValueToTheConsole(
+            object root, 
+            string expectedValue,
+            string? headingUnderline)
+        {
+            AssertWriteHeading(root, expectedValue, headingUnderline);
+        }
+
+        [TestCase("Test a string", "Test a string", null, 0)]
+        [TestCase("Test a string", "Test a string", null, 1)]
+        [TestCase("Test a string", "Test a string", null, 2)]
+        [TestCase(1, "1", null, 0)]
+        [TestCase(1, "1", null, 1)]
+        [TestCase(1, "1", null, 2)]
+        [TestCase(true, "True", null, 0)]
+        [TestCase(true, "True", null, 1)]
+        [TestCase(true, "True", null, 2)]
+        [TestCase(false, "False", null, 0)]
+        [TestCase(false, "False", null, 1)]
+        [TestCase(false, "False", null, 2)]
+        [TestCase("Test a string", "Test a string", "-", 0)]
+        [TestCase("Test a string", "Test a string", "-", 1)]
+        [TestCase("Test a string", "Test a string", "-", 2)]
+        [TestCase(1, "1", "-", 0)]
+        [TestCase(1, "1", "-", 1)]
+        [TestCase(1, "1", "-", 2)]
+        [TestCase(true, "True", "-", 0)]
+        [TestCase(true, "True", "-", 1)]
+        [TestCase(true, "True", "-", 2)]
+        [TestCase(false, "False", "-", 0)]
+        [TestCase(false, "False", "-", 1)]
+        [TestCase(false, "False", "-", 2)]
+        [TestCase("Test a string", "Test a string", "++", 0)]
+        [TestCase("Test a string", "Test a string", "++", 1)]
+        [TestCase("Test a string", "Test a string", "++", 2)]
+        [TestCase(1, "1", "++", 0)]
+        [TestCase(1, "1", "++", 1)]
+        [TestCase(1, "1", "++", 2)]
+        [TestCase(true, "True", "++", 0)]
+        [TestCase(true, "True", "++", 1)]
+        [TestCase(true, "True", "++", 2)]
+        [TestCase(false, "False", "++", 0)]
+        [TestCase(false, "False", "++", 1)]
+        [TestCase(false, "False", "++", 2)]
+        [TestCase("Test a string", "Test a string", "___", 0)]
+        [TestCase("Test a string", "Test a string", "___", 1)]
+        [TestCase("Test a string", "Test a string", "___", 2)]
+        [TestCase(1, "1", "___", 0)]
+        [TestCase(1, "1", "___", 1)]
+        [TestCase(1, "1", "___", 2)]
+        [TestCase(true, "True", "___", 0)]
+        [TestCase(true, "True", "___", 1)]
+        [TestCase(true, "True", "___", 2)]
+        [TestCase(false, "False", "___", 0)]
+        [TestCase(false, "False", "___", 1)]
+        [TestCase(false, "False", "___", 2)]
+        public void WriteHeading_WhenWritingFromANonNullObjectWithLineAppends_LogsTheExpectedValueToTheConsole(
+            object root,
+            string expectedValue,
+            string? headingUnderline,
+            int numberOfLineAppends)
+        {
+            AssertWriteHeadingWithLineAppends(root, expectedValue, headingUnderline, numberOfLineAppends);
+        }
+
+        [TestCase("Test a string", "Test a string")]
+        [TestCase(1, "1")]
+        [TestCase(true, "True")]
+        [TestCase(false, "False")]
+        public void Write_WhenWritingFromANonNullObject_LogsTheExpectedValueToTheConsole(object root, string expectedValue)
+        {
+            AssertWrite(root, expectedValue);
+        }
+
+        [TestCase("Test a string", 0)]
+        [TestCase(1, 1)]
+        [TestCase(1.0, 2)]
+        [TestCase(1.0f, 3)]
+        [TestCase(true, 4)]
+        [TestCase(false, 5)]
+        public void WriteLines_WhenWritingFromANonNullObject_LogsTheExpectedValueToTheConsole(object root, int numberOfWriteLines)
+        {
+            AssertWriteLines(root, numberOfWriteLines);
+        }
+
+        [TestCase("Name X")]
+        [TestCase("X Name")]
+        [TestCase("Tenjin")]
+        public void WriteLine_WhenWritingFromACustomObject_LogsTheExpectedValueToTheConsole(string name)
+        {
+            var customObject = new ConsoleObject(name);
+            var expectedValue = ConsoleObject.GetOutputText(name);
+
+            AssertWriteLine(customObject, expectedValue);
+        }
+
+        [TestCase("Name X", 0)]
+        [TestCase("X Name", 1)]
+        [TestCase("Tenjin", 2)]
+        public void WriteLine_WhenWritingFromACustomObjectWithLineAppends_LogsTheExpectedValueToTheConsole(
+            string name,
+            int numberOfLineAppends)
+        {
+            var customObject = new ConsoleObject(name);
+            var expectedValue = ConsoleObject.GetOutputText(name);
+
+            AssertWriteLineWithLineAppends(customObject, expectedValue, numberOfLineAppends);
+        }
+
+        [TestCase("Name X", null)]
+        [TestCase("X Name", null)]
+        [TestCase("Tenjin", null)]
+        [TestCase("Name X", "-")]
+        [TestCase("X Name", "-")]
+        [TestCase("Tenjin", "-")]
+        [TestCase("Name X", "++")]
+        [TestCase("X Name", "++")]
+        [TestCase("Tenjin", "++")]
+        [TestCase("Name X", "___")]
+        [TestCase("X Name", "___")]
+        [TestCase("Tenjin", "___")]
+        public void WriteHeading_WhenWritingFromACustomObject_LogsTheExpectedValueToTheConsole(string name, string? headingUnderline)
+        {
+            var customObject = new ConsoleObject(name);
+            var expectedValue = ConsoleObject.GetOutputText(name);
+
+            AssertWriteHeading(customObject, expectedValue);
+        }
+
+        [TestCase("Name X", 0, null)]
+        [TestCase("X Name", 1, null)]
+        [TestCase("Tenjin", 2, null)]
+        [TestCase("Name X", 0, "-")]
+        [TestCase("X Name", 1, "-")]
+        [TestCase("Tenjin", 2, "-")]
+        [TestCase("Name X", 0, "==")]
+        [TestCase("X Name", 1, "==")]
+        [TestCase("Tenjin", 2, "==")]
+        [TestCase("Name X", 0, "___")]
+        [TestCase("X Name", 1, "___")]
+        [TestCase("Tenjin", 2, "___")]
+        public void WriteHeading_WhenWritingFromACustomObjectWithLineAppends_LogsTheExpectedValueToTheConsole(
+            string name,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var customObject = new ConsoleObject(name);
+            var expectedValue = ConsoleObject.GetOutputText(name);
+
+            AssertWriteHeadingWithLineAppends(customObject, expectedValue, headingUnderline, numberOfLineAppends);
+        }
+
+        [TestCase("Name X")]
+        [TestCase("X Name")]
+        [TestCase("Tenjin")]
+        public void Write_WhenWritingFromACustomObject_LogsTheExpectedValueToTheConsole(string name)
+        {
+            var customObject = new ConsoleObject(name);
+            var expectedValue = ConsoleObject.GetOutputText(name);
+
+            AssertWrite(customObject, expectedValue);
+        }
+
+        [Test]
+        public void WriteLine_WhenWritingNullableFormattableObjects_LogsAnEmptyString()
+        {
+            AssertWriteLineWithFormat(null, "bogus-format-string", null, string.Empty);
+        }
+
+        [TestCase(null)]
+        [TestCase("-")]
+        [TestCase("==")]
+        [TestCase("___")]
+        public void WriteHeading_WhenWritingNullableFormattableObjects_LogsAnEmptyString(string? headerUnderline)
+        {
+            AssertWriteHeadingWithFormat(null, null, null, string.Empty, headerUnderline);
+        }
+
+        [Test]
+        public void Write_WhenWritingNullableFormattableObjects_LogsAnEmptyString()
+        {
+            AssertWriteWithFormat(null, "bogus-format-string", null, string.Empty);
+        }
+
+        [TestCase("2000-01-01")]
+        [TestCase("2005-01-05")]
+        [TestCase("2005-02-10")]
+        [TestCase("2010-10-10")]
+        [TestCase("2020-12-31")]
+        public void WriteLine_WhenWritingDateTimeWithFormatString_LogsTheExpectedValueToTheConsole(string value)
+        {
+            var dateTime = DateTime.ParseExact(value, DateTimeWriteLineInputFormat, null);
+            var expectedValue = dateTime.ToString(DateTimeWriteLineOutputFormat);
+
+            AssertWriteLineWithFormat(dateTime, DateTimeWriteLineOutputFormat, null, expectedValue);
+        }
+
+        [TestCase("2000-01-01", 0)]
+        [TestCase("2005-01-05", 1)]
+        [TestCase("2005-02-10", 2)]
+        [TestCase("2010-10-10", 3)]
+        [TestCase("2020-12-31", 4)]
+        public void WriteLine_WhenWritingDateTimeWithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            string value,
+            int numberOfLineAppends)
+        {
+            var dateTime = DateTime.ParseExact(value, DateTimeWriteLineInputFormat, null);
+            var expectedValue = dateTime.ToString(DateTimeWriteLineOutputFormat);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                dateTime, numberOfLineAppends, DateTimeWriteLineOutputFormat, null, expectedValue);
+        }
+
+        [TestCase("2000-01-01", null)]
+        [TestCase("2005-01-05", null)]
+        [TestCase("2005-02-10", null)]
+        [TestCase("2010-10-10", null)]
+        [TestCase("2020-12-31", null)]
+        [TestCase("2000-01-01", "-")]
+        [TestCase("2005-01-05", "-")]
+        [TestCase("2005-02-10", "-")]
+        [TestCase("2010-10-10", "-")]
+        [TestCase("2020-12-31", "-")]
+        [TestCase("2000-01-01", "==")]
+        [TestCase("2005-01-05", "==")]
+        [TestCase("2005-02-10", "==")]
+        [TestCase("2010-10-10", "==")]
+        [TestCase("2020-12-31", "==")]
+        [TestCase("2000-01-01", "___")]
+        [TestCase("2005-01-05", "___")]
+        [TestCase("2005-02-10", "___")]
+        [TestCase("2010-10-10", "___")]
+        [TestCase("2020-12-31", "___")]
+        public void WriteHeading_WhenWritingDateTimeWithFormatString_LogsTheExpectedValueToTheConsole(string value, string? headingUnderline)
+        {
+            var dateTime = DateTime.ParseExact(value, DateTimeWriteLineInputFormat, null);
+            var expectedValue = dateTime.ToString(DateTimeWriteLineOutputFormat);
+
+            AssertWriteHeadingWithFormat(dateTime, DateTimeWriteLineOutputFormat, null, expectedValue, headingUnderline);
+        }
+
+        [TestCase("2000-01-01", 0, null)]
+        [TestCase("2005-01-05", 1, null)]
+        [TestCase("2005-02-10", 2, null)]
+        [TestCase("2010-10-10", 3, null)]
+        [TestCase("2020-12-31", 4, null)]
+        [TestCase("2000-01-01", 0, "+")]
+        [TestCase("2005-01-05", 1, "+")]
+        [TestCase("2005-02-10", 2, "+")]
+        [TestCase("2010-10-10", 3, "+")]
+        [TestCase("2020-12-31", 4, "+")]
+        [TestCase("2000-01-01", 0, "--")]
+        [TestCase("2005-01-05", 1, "--")]
+        [TestCase("2005-02-10", 2, "--")]
+        [TestCase("2010-10-10", 3, "--")]
+        [TestCase("2020-12-31", 4, "--")]
+        [TestCase("2000-01-01", 0, "___")]
+        [TestCase("2005-01-05", 1, "___")]
+        [TestCase("2005-02-10", 2, "___")]
+        [TestCase("2010-10-10", 3, "___")]
+        [TestCase("2020-12-31", 4, "___")]
+        public void WriteHeading_WhenWritingDateTimeWithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            string value,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var dateTime = DateTime.ParseExact(value, DateTimeWriteLineInputFormat, null);
+            var expectedValue = dateTime.ToString(DateTimeWriteLineOutputFormat);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                dateTime, numberOfLineAppends, DateTimeWriteLineOutputFormat, null, expectedValue, headingUnderline);
+        }
+
+        [TestCase("2000-01-01")]
+        [TestCase("2005-01-05")]
+        [TestCase("2005-02-10")]
+        [TestCase("2010-10-10")]
+        [TestCase("2020-12-31")]
+        public void Write_WhenWritingDateTimeWithFormatString_LogsTheExpectedValueToTheConsole(string value)
+        {
+            var dateTime = DateTime.ParseExact(value, DateTimeWriteLineInputFormat, null);
+            var expectedValue = dateTime.ToString(DateTimeWriteLineOutputFormat);
+
+            AssertWriteWithFormat(dateTime, DateTimeWriteLineOutputFormat, null, expectedValue);
+        }
+
+        [TestCase((ushort)255, "X", "FF")]
+        [TestCase((ushort)255, "x", "ff")]
+        public void WriteLine_WhenWritingUInt16WithFormatString_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteLineWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00")]
+        [TestCase((ushort)100, "F", "en-US", "100.000")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %")]
+        public void WriteLine_WhenWritingUInt16WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((uint)255, "X", "FF")]
+        [TestCase((uint)255, "x", "ff")]
+        public void WriteLine_WhenWritingUInt32WithFormatString_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteLineWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %")]
+        public void WriteLine_WhenWritingUInt32WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((ulong)255, "X", "FF")]
+        [TestCase((ulong)255, "x", "ff")]
+        public void WriteLine_WhenWritingUInt64WithFormatString_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteLineWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %")]
+        public void WriteLine_WhenWritingUInt64WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF")]
+        [TestCase(255, "x", "ff")]
+        public void WriteLine_WhenWritingInt16WithFormatString_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteLineWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase(100, "C", "en-ZA", "R100,00")]
+        [TestCase(100, "F", "en-US", "100.000")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %")]
+        public void WriteLine_WhenWritingInt16WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            short value, 
+            string? format, 
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF")]
+        [TestCase(255, "x", "ff")]
+        public void WriteLine_WhenWritingInt32WithFormatString_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteLineWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00")]
+        [TestCase(1000000, "F", "en-US", "1000000.000")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %")]
+        public void WriteLine_WhenWritingInt32WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF")]
+        [TestCase(255, "x", "ff")]
+        public void WriteLine_WhenWritingInt64WithFormatString_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteLineWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00")]
+        [TestCase(100000000, "F", "en-US", "100000000.000")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %")]
+        public void WriteLine_WhenWritingInt64WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %")]
+        public void WriteLine_WhenWritingFloatWithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            float value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %")]
+        public void WriteLine_WhenWritingDoubleWithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            double value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((ushort)255, "X", "FF", 0)]
+        [TestCase((ushort)255, "x", "ff", 1)]
+        public void WriteLine_WhenWritingUInt16WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithFormatWithLineAppends(value, numberOfLineAppends, format, null, expectedResult);
+        }
+
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", 0)]
+        [TestCase((ushort)100, "F", "en-US", "100.000", 1)]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", 2)]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", 3)]
+        public void WriteLine_WhenWritingUInt16WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((uint)255, "X", "FF", 0)]
+        [TestCase((uint)255, "x", "ff", 1)]
+        public void WriteLine_WhenWritingUInt32WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithFormatWithLineAppends(value, numberOfLineAppends, format, null, expectedResult);
+        }
+
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", 0)]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", 1)]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", 2)]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", 3)]
+        public void WriteLine_WhenWritingUInt32WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((ulong)255, "X", "FF", 0)]
+        [TestCase((ulong)255, "x", "ff", 1)]
+        public void WriteLine_WhenWritingUInt64WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithFormatWithLineAppends(value, numberOfLineAppends, format, null, expectedResult);
+        }
+
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", 0)]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", 1)]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", 2)]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", 3)]
+        public void WriteLine_WhenWritingUInt64WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF", 0)]
+        [TestCase(255, "x", "ff", 1)]
+        public void WriteLine_WhenWritingInt16WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithFormatWithLineAppends(value, numberOfLineAppends, format, null, expectedResult);
+        }
+
+        [TestCase(100, "C", "en-ZA", "R100,00", 0)]
+        [TestCase(100, "F", "en-US", "100.000", 1)]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", 2)]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", 3)]
+        public void WriteLine_WhenWritingInt16WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF", 0)]
+        [TestCase(255, "x", "ff", 1)]
+        public void WriteLine_WhenWritingInt32WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithFormatWithLineAppends(value, numberOfLineAppends, format, null, expectedResult);
+        }
+
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", 0)]
+        [TestCase(1000000, "F", "en-US", "1000000.000", 1)]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", 2)]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", 3)]
+        public void WriteLine_WhenWritingInt32WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF", 0)]
+        [TestCase(255, "x", "ff", 1)]
+        public void WriteLine_WhenWritingInt64WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            AssertWriteLineWithFormatWithLineAppends(value, numberOfLineAppends, format, null, expectedResult);
+        }
+
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", 0)]
+        [TestCase(100000000, "F", "en-US", "100000000.000", 1)]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", 2)]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", 3)]
+        public void WriteLine_WhenWritingInt64WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", 0)]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", 1)]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", 2)]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", 3)]
+        public void WriteLine_WhenWritingFloatWithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            float value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", 0)]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", 1)]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", 2)]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", 3)]
+        public void WriteLine_WhenWritingDoubleWithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            double value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteLineWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult);
+        }
+        
+        [TestCase((ushort)255, "X", "FF", null)]
+        [TestCase((ushort)255, "x", "ff", null)]
+        [TestCase((ushort)255, "X", "FF", "-")]
+        [TestCase((ushort)255, "x", "ff", "-")]
+        [TestCase((ushort)255, "X", "FF", "++")]
+        [TestCase((ushort)255, "x", "ff", "++")]
+        [TestCase((ushort)255, "X", "FF", "___")]
+        [TestCase((ushort)255, "x", "ff", "___")]
+        public void WriteHeading_WhenWritingUInt16WithFormatString_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormat(value, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", null)]
+        [TestCase((ushort)100, "F", "en-US", "100.000", null)]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", null)]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", null)]
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", "-")]
+        [TestCase((ushort)100, "F", "en-US", "100.000", "-")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", "-")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", "-")]
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", "++")]
+        [TestCase((ushort)100, "F", "en-US", "100.000", "++")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", "++")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", "++")]
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", "___")]
+        [TestCase((ushort)100, "F", "en-US", "100.000", "___")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", "___")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", "___")]
+        public void WriteHeading_WhenWritingUInt16WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase((uint)255, "X", "FF", null)]
+        [TestCase((uint)255, "x", "ff", null)]
+        [TestCase((uint)255, "X", "FF", "-")]
+        [TestCase((uint)255, "x", "ff", "-")]
+        [TestCase((uint)255, "X", "FF", "++")]
+        [TestCase((uint)255, "x", "ff", "++")]
+        [TestCase((uint)255, "X", "FF", "___")]
+        [TestCase((uint)255, "x", "ff", "___")]
+        public void WriteHeading_WhenWritingUInt32WithFormatString_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", null)]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", null)]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", null)]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", null)]
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", "-")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", "-")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", "-")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", "-")]
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", "++")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", "++")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", "++")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", "++")]
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", "___")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", "___")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", "___")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", "___")]
+        public void WriteHeading_WhenWritingUInt32WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ulong)255, "X", "FF", null)]
+        [TestCase((ulong)255, "x", "ff", null)]
+        [TestCase((ulong)255, "X", "FF", "-")]
+        [TestCase((ulong)255, "x", "ff", "-")]
+        [TestCase((ulong)255, "X", "FF", "++")]
+        [TestCase((ulong)255, "x", "ff", "++")]
+        [TestCase((ulong)255, "X", "FF", "___")]
+        [TestCase((ulong)255, "x", "ff", "___")]
+        public void WriteHeading_WhenWritingUInt64WithFormatString_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", null)]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", null)]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", null)]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", null)]
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", "-")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", "-")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", "-")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", "-")]
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", "++")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", "++")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", "++")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", "++")]
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", "___")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", "___")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", "___")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", "___")]
+        public void WriteHeading_WhenWritingUInt64WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(255, "X", "FF", null)]
+        [TestCase(255, "x", "ff", null)]
+        [TestCase(255, "X", "FF", "-")]
+        [TestCase(255, "x", "ff", "-")]
+        [TestCase(255, "X", "FF", "++")]
+        [TestCase(255, "x", "ff", "++")]
+        [TestCase(255, "X", "FF", "___")]
+        [TestCase(255, "x", "ff", "___")]
+        public void WriteHeading_WhenWritingInt16WithFormatString_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormat(value, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100, "C", "en-ZA", "R100,00", null)]
+        [TestCase(100, "F", "en-US", "100.000", null)]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", null)]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", null)]
+        [TestCase(100, "C", "en-ZA", "R100,00", "-")]
+        [TestCase(100, "F", "en-US", "100.000", "-")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", "-")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", "-")]
+        [TestCase(100, "C", "en-ZA", "R100,00", "++")]
+        [TestCase(100, "F", "en-US", "100.000", "++")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", "++")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", "++")]
+        [TestCase(100, "C", "en-ZA", "R100,00", "___")]
+        [TestCase(100, "F", "en-US", "100.000", "___")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", "___")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", "___")]
+        public void WriteHeading_WhenWritingInt16WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(255, "X", "FF", null)]
+        [TestCase(255, "x", "ff", null)]
+        [TestCase(255, "X", "FF", "-")]
+        [TestCase(255, "x", "ff", "-")]
+        [TestCase(255, "X", "FF", "++")]
+        [TestCase(255, "x", "ff", "++")]
+        [TestCase(255, "X", "FF", "___")]
+        [TestCase(255, "x", "ff", "___")]
+        public void WriteHeading_WhenWritingInt32WithFormatString_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormat(value, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", null)]
+        [TestCase(1000000, "F", "en-US", "1000000.000", null)]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", null)]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", null)]
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", "-")]
+        [TestCase(1000000, "F", "en-US", "1000000.000", "-")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", "-")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", "-")]
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", "++")]
+        [TestCase(1000000, "F", "en-US", "1000000.000", "++")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", "++")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", "++")]
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", "___")]
+        [TestCase(1000000, "F", "en-US", "1000000.000", "___")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", "___")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", "___")]
+        public void WriteHeading_WhenWritingInt32WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(255, "X", "FF", null)]
+        [TestCase(255, "x", "ff", null)]
+        [TestCase(255, "X", "FF", "-")]
+        [TestCase(255, "x", "ff", "-")]
+        [TestCase(255, "X", "FF", "++")]
+        [TestCase(255, "x", "ff", "++")]
+        [TestCase(255, "X", "FF", "___")]
+        [TestCase(255, "x", "ff", "___")]
+        public void WriteHeading_WhenWritingInt64WithFormatString_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormat(value, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", null)]
+        [TestCase(100000000, "F", "en-US", "100000000.000", null)]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", null)]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", null)]
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", "-")]
+        [TestCase(100000000, "F", "en-US", "100000000.000", "-")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", "-")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", "-")]
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", "++")]
+        [TestCase(100000000, "F", "en-US", "100000000.000", "++")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", "++")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", "++")]
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", "___")]
+        [TestCase(100000000, "F", "en-US", "100000000.000", "___")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", "___")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", "___")]
+        public void WriteHeading_WhenWritingInt64WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", null)]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", null)]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", null)]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", null)]
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", "-")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", "-")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", "-")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", "-")]
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", "++")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", "++")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", "++")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", "++")]
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", "___")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", "___")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", "___")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", "___")]
+        public void WriteHeading_WhenWritingFloatWithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            float value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", null)]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", null)]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", null)]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", null)]
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", "-")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", "-")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", "-")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", "-")]
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", "++")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", "++")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", "++")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", "++")]
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", "___")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", "___")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", "___")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", "___")]
+        public void WriteHeading_WhenWritingDoubleWithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            double value,
+            string? format,
+            string culture,
+            string expectedResult,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormat(value, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ushort)255, "X", "FF", 0, null)]
+        [TestCase((ushort)255, "x", "ff", 1, null)]
+        [TestCase((ushort)255, "X", "FF", 0, "-")]
+        [TestCase((ushort)255, "x", "ff", 1, "-")]
+        [TestCase((ushort)255, "X", "FF", 0, "++")]
+        [TestCase((ushort)255, "x", "ff", 1, "++")]
+        [TestCase((ushort)255, "X", "FF", 0, "___")]
+        [TestCase((ushort)255, "x", "ff", 1, "___")]
+        public void WriteHeading_WhenWritingUInt16WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", 0, null)]
+        [TestCase((ushort)100, "F", "en-US", "100.000", 1, null)]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", 2, null)]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", 3, null)]
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", 0, "-")]
+        [TestCase((ushort)100, "F", "en-US", "100.000", 1, "-")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", 2, "-")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", 3, "-")]
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", 0, "++")]
+        [TestCase((ushort)100, "F", "en-US", "100.000", 1, "++")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", 2, "++")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", 3, "++")]
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00", 0, "___")]
+        [TestCase((ushort)100, "F", "en-US", "100.000", 1, "___")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002", 2, "___")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingUInt16WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase((uint)255, "X", "FF", 0, null)]
+        [TestCase((uint)255, "x", "ff", 1, null)]
+        [TestCase((uint)255, "X", "FF", 0, "-")]
+        [TestCase((uint)255, "x", "ff", 1, "-")]
+        [TestCase((uint)255, "X", "FF", 0, "++")]
+        [TestCase((uint)255, "x", "ff", 1, "++")]
+        [TestCase((uint)255, "X", "FF", 0, "___")]
+        [TestCase((uint)255, "x", "ff", 1, "___")]
+        public void WriteHeading_WhenWritingUInt32WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", 0, null)]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", 1, null)]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", 2, null)]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", 3, null)]
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", 0, "-")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", 1, "-")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", 2, "-")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", 3, "-")]
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", 0, "++")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", 1, "++")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", 2, "++")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", 3, "++")]
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00", 0, "___")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000", 1, "___")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006", 2, "___")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingUInt32WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ulong)255, "X", "FF", 0, null)]
+        [TestCase((ulong)255, "x", "ff", 1, null)]
+        [TestCase((ulong)255, "X", "FF", 0, "-")]
+        [TestCase((ulong)255, "x", "ff", 1, "-")]
+        [TestCase((ulong)255, "X", "FF", 0, "++")]
+        [TestCase((ulong)255, "x", "ff", 1, "++")]
+        [TestCase((ulong)255, "X", "FF", 0, "___")]
+        [TestCase((ulong)255, "x", "ff", 1, "___")]
+        public void WriteHeading_WhenWritingUInt64WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", 0, null)]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", 1, null)]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", 2, null)]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, null)]
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", 0, "-")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", 1, "-")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", 2, "-")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, "-")]
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", 0, "++")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", 1, "++")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", 2, "++")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, "++")]
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00", 0, "___")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000", 1, "___")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008", 2, "___")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingUInt64WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(255, "X", "FF", 0, null)]
+        [TestCase(255, "x", "ff", 1, null)]
+        [TestCase(255, "X", "FF", 0, "-")]
+        [TestCase(255, "x", "ff", 1, "-")]
+        [TestCase(255, "X", "FF", 0, "++")]
+        [TestCase(255, "x", "ff", 1, "++")]
+        [TestCase(255, "X", "FF", 0, "___")]
+        [TestCase(255, "x", "ff", 1, "___")]
+        public void WriteHeading_WhenWritingInt16WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100, "C", "en-ZA", "R100,00", 0, null)]
+        [TestCase(100, "F", "en-US", "100.000", 1, null)]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", 2, null)]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", 3, null)]
+        [TestCase(100, "C", "en-ZA", "R100,00", 0, "-")]
+        [TestCase(100, "F", "en-US", "100.000", 1, "-")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", 2, "-")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", 3, "-")]
+        [TestCase(100, "C", "en-ZA", "R100,00", 0, "++")]
+        [TestCase(100, "F", "en-US", "100.000", 1, "++")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", 2, "++")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", 3, "++")]
+        [TestCase(100, "C", "en-ZA", "R100,00", 0, "___")]
+        [TestCase(100, "F", "en-US", "100.000", 1, "___")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002", 2, "___")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingInt16WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(255, "X", "FF", 0, null)]
+        [TestCase(255, "x", "ff", 1, null)]
+        [TestCase(255, "X", "FF", 0, "-")]
+        [TestCase(255, "x", "ff", 1, "-")]
+        [TestCase(255, "X", "FF", 0, "++")]
+        [TestCase(255, "x", "ff", 1, "++")]
+        [TestCase(255, "X", "FF", 0, "___")]
+        [TestCase(255, "x", "ff", 1, "___")]
+        public void WriteHeading_WhenWritingInt32WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", 0, null)]
+        [TestCase(1000000, "F", "en-US", "1000000.000", 1, null)]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", 2, null)]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", 3, null)]
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", 0, "-")]
+        [TestCase(1000000, "F", "en-US", "1000000.000", 1, "-")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", 2, "-")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", 3, "-")]
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", 0, "++")]
+        [TestCase(1000000, "F", "en-US", "1000000.000", 1, "++")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", 2, "++")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", 3, "++")]
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00", 0, "___")]
+        [TestCase(1000000, "F", "en-US", "1000000.000", 1, "___")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006", 2, "___")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingInt32WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(255, "X", "FF", 0, null)]
+        [TestCase(255, "x", "ff", 1, null)]
+        [TestCase(255, "X", "FF", 0, "-")]
+        [TestCase(255, "x", "ff", 1, "-")]
+        [TestCase(255, "X", "FF", 0, "++")]
+        [TestCase(255, "x", "ff", 1, "++")]
+        [TestCase(255, "X", "FF", 0, "___")]
+        [TestCase(255, "x", "ff", 1, "___")]
+        public void WriteHeading_WhenWritingInt64WithFormatStringWithLineAppends_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, null, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", 0, null)]
+        [TestCase(100000000, "F", "en-US", "100000000.000", 1, null)]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", 2, null)]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, null)]
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", 0, "-")]
+        [TestCase(100000000, "F", "en-US", "100000000.000", 1, "-")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", 2, "-")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, "-")]
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", 0, "++")]
+        [TestCase(100000000, "F", "en-US", "100000000.000", 1, "++")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", 2, "++")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, "++")]
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00", 0, "___")]
+        [TestCase(100000000, "F", "en-US", "100000000.000", 1, "___")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008", 2, "___")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingInt64WithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", 0, null)]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", 1, null)]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", 2, null)]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", 3, null)]
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", 0, "-")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", 1, "-")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", 2, "-")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", 3, "-")]
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", 0, "++")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", 1, "++")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", 2, "++")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", 3, "++")]
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00", 0, "___")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000", 1, "___")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008", 2, "___")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %", 3, "___")]
+        public void WriteHeading_WhenWritingFloatWithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            float value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", 0, null)]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", 1, null)]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", 2, null)]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", 3, null)]
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", 0, "-")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", 1, "-")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", 2, "-")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", 3, "-")]
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", 0, "++")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", 1, "++")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", 2, "++")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", 3, "++")]
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33", 0, "___")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334", 1, "___")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008", 2, "___")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %", 3, "___")]
+        public void WriteHeading_WhenWritingDoubleWithFormatStringAndFormatProviderWithLineAppends_LogsTheExpectedValueToTheConsole(
+            double value,
+            string? format,
+            string culture,
+            string expectedResult,
+            int numberOfLineAppends,
+            string? headingUnderline)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteHeadingWithFormatWithLineAppends(
+                value, numberOfLineAppends, format, formatProvider, expectedResult, headingUnderline);
+        }
+
+        [TestCase((ushort)255, "X", "FF")]
+        [TestCase((ushort)255, "x", "ff")]
+        public void Write_WhenWritingUInt16WithFormatString_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((ushort)100, "C", "en-ZA", "R100,00")]
+        [TestCase((ushort)100, "F", "en-US", "100.000")]
+        [TestCase((ushort)100, "E", "nl-NL", "1,000000E+002")]
+        [TestCase((ushort)100, "P", "fr-FR", "10 000,000 %")]
+        public void Write_WhenWritingUInt16WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            ushort value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((uint)255, "X", "FF")]
+        [TestCase((uint)255, "x", "ff")]
+        public void Write_WhenWritingUInt32WithFormatString_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((uint)1000000, "C", "en-ZA", "R1 000 000,00")]
+        [TestCase((uint)1000000, "F", "en-US", "1000000.000")]
+        [TestCase((uint)1000000, "E", "nl-NL", "1,000000E+006")]
+        [TestCase((uint)1000000, "P", "fr-FR", "100 000 000,000 %")]
+        public void Write_WhenWritingUInt32WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            uint value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase((ulong)255, "X", "FF")]
+        [TestCase((ulong)255, "x", "ff")]
+        public void Write_WhenWritingUInt64WithFormatString_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase((ulong)100000000, "C", "en-ZA", "R100 000 000,00")]
+        [TestCase((ulong)100000000, "F", "en-US", "100000000.000")]
+        [TestCase((ulong)100000000, "E", "nl-NL", "1,000000E+008")]
+        [TestCase((ulong)100000000, "P", "fr-FR", "10 000 000 000,000 %")]
+        public void Write_WhenWritingUInt64WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            ulong value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF")]
+        [TestCase(255, "x", "ff")]
+        public void Write_WhenWritingInt16WithFormatString_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase(100, "C", "en-ZA", "R100,00")]
+        [TestCase(100, "F", "en-US", "100.000")]
+        [TestCase(100, "E", "nl-NL", "1,000000E+002")]
+        [TestCase(100, "P", "fr-FR", "10 000,000 %")]
+        public void Write_WhenWritingInt16WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            short value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF")]
+        [TestCase(255, "x", "ff")]
+        public void Write_WhenWritingInt32WithFormatString_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase(1000000, "C", "en-ZA", "R1 000 000,00")]
+        [TestCase(1000000, "F", "en-US", "1000000.000")]
+        [TestCase(1000000, "E", "nl-NL", "1,000000E+006")]
+        [TestCase(1000000, "P", "fr-FR", "100 000 000,000 %")]
+        public void Write_WhenWritingInt32WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            int value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(255, "X", "FF")]
+        [TestCase(255, "x", "ff")]
+        public void Write_WhenWritingInt64WithFormatString_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string expectedResult)
+        {
+            AssertWriteWithFormat(value, format, null, expectedResult);
+        }
+
+        [TestCase(100000000, "C", "en-ZA", "R100 000 000,00")]
+        [TestCase(100000000, "F", "en-US", "100000000.000")]
+        [TestCase(100000000, "E", "nl-NL", "1,000000E+008")]
+        [TestCase(100000000, "P", "fr-FR", "10 000 000 000,000 %")]
+        public void Write_WhenWritingInt64WithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            long value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(100000000.334f, "C", "en-ZA", "R100 000 000,00")]
+        [TestCase(100000000.334f, "F", "en-US", "100000000.000")]
+        [TestCase(100000000.334f, "E", "nl-NL", "1,000000E+008")]
+        [TestCase(100000000.334f, "P", "fr-FR", "10 000 000 000,000 %")]
+        public void Write_WhenWritingFloatWithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            float value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        [TestCase(100000000.334, "C", "en-ZA", "R100 000 000,33")]
+        [TestCase(100000000.334, "F", "en-US", "100000000.334")]
+        [TestCase(100000000.334, "E", "nl-NL", "1,000000E+008")]
+        [TestCase(100000000.334, "P", "fr-FR", "10 000 000 033,400 %")]
+        public void Write_WhenWritingDoubleWithFormatStringAndFormatProvider_LogsTheExpectedValueToTheConsole(
+            double value,
+            string? format,
+            string culture,
+            string expectedResult)
+        {
+            var formatProvider = CultureInfo.GetCultureInfo(culture, true);
+
+            AssertWriteWithFormat(value, format, formatProvider, expectedResult);
+        }
+
+        private static void AssertWriteWithFormat(
+            IFormattable? root,
+            string? format,
+            IFormatProvider? formatProvider,
+            string expectedValue)
+        {
+            using var monitor = new ConsoleTestMonitor();
+
+            root.Write(format, formatProvider);
+
+            Assert.AreEqual(expectedValue, monitor.GetOutputText());
+        }
+
+        private static void AssertWriteLines(
+            object? root,
+            int numberOfWriteLines)
+        {
+            using var monitor = new ConsoleTestMonitor();
+            var testValue = new StringBuilder();
+
+            for (var i = 0; i < numberOfWriteLines; i++)
+            {
+                testValue.Append(Environment.NewLine);
+            }
+
+            root.WriteLines(numberOfWriteLines);
+
+            Assert.AreEqual(testValue.ToString(), monitor.GetOutputText());
+        }
+
+        private static void AssertWrite(
+            object? root,
+            string expectedValue)
+        {
+            using var monitor = new ConsoleTestMonitor();
+
+            root.Write();
+
+            Assert.AreEqual(expectedValue, monitor.GetOutputText());
+        }
+
+        private static void AssertWriteLine(
+            object? root,
+            string expectedValue)
+        {
+            GlobalAssertWriteLine(expectedValue, null, () => root.WriteLine());
+        }
+
+        private static void AssertWriteLineWithLineAppends(
+            object? root,
+            string expectedValue,
+            int numberOfLineAppends)
+        {
+            GlobalAssertWriteLine(expectedValue, numberOfLineAppends, () => 
+                root.WriteLine(numberOfLineAppends));
+        }
+
+        private static void AssertWriteLineWithFormat(
+            IFormattable? root,
+            string? format,
+            IFormatProvider? formatProvider,
+            string expectedValue)
+        {
+            GlobalAssertWriteLine(expectedValue, null, () =>
+                root.WriteLine(format, formatProvider));
+        }
+
+        private static void AssertWriteLineWithFormatWithLineAppends(
+            IFormattable? root,
+            int numberOfLineAppends,
+            string? format,
+            IFormatProvider? formatProvider,
+            string expectedValue)
+        {
+            GlobalAssertWriteLine(expectedValue, numberOfLineAppends, () =>
+                root.WriteLine(format, formatProvider, numberOfLineAppends));
+        }
+
+        private static void AssertWriteHeading(
+            object? root,
+            string expectedValue,
+            string? headingUnderline = null)
+        {
+            GlobalAssertWriteHeading(expectedValue, null, headingUnderline, () =>
+                root.WriteHeading(headingUnderline));
+        }
+
+        private static void AssertWriteHeadingWithLineAppends(
+            object? root,
+            string expectedValue,
+            string? headingUnderline,
+            int numberOfLineAppends)
+        {
+            GlobalAssertWriteHeading(expectedValue, numberOfLineAppends, headingUnderline, () =>
+                root.WriteHeading(headingUnderline, numberOfLineAppends));
+        }
+
+        private static void AssertWriteHeadingWithFormat(
+            IFormattable? root,
+            string? format,
+            IFormatProvider? formatProvider,
+            string expectedValue,
+            string? headingUnderline = null)
+        {
+            GlobalAssertWriteHeading(expectedValue, null, headingUnderline, () =>
+                root.WriteHeading(format, formatProvider, headingUnderline));
+        }
+
+        private static void AssertWriteHeadingWithFormatWithLineAppends(
+            IFormattable? root,
+            int numberOfLineAppends,
+            string? format,
+            IFormatProvider? formatProvider,
+            string expectedValue,
+            string? headingUnderline = null)
+        {
+            GlobalAssertWriteHeading(expectedValue, numberOfLineAppends, headingUnderline, () =>
+                root.WriteHeading(format, formatProvider, headingUnderline, numberOfLineAppends));
+        }
+
+        private static void GlobalAssertWriteLine(
+            string expectedValue,
+            int? numberOfLineAppends,
+            Action writeToRoot)
+        {
+            using var monitor = new ConsoleTestMonitor();
+            var testValue = new StringBuilder($"{expectedValue}{Environment.NewLine}");
+
+            if (numberOfLineAppends.HasValue)
+            {
+                for (var i = 0; i < numberOfLineAppends; i++)
+                {
+                    testValue.Append(Environment.NewLine);
+                }
+            }
+
+            writeToRoot();
+
+            Assert.AreEqual(testValue.ToString(), monitor.GetOutputText());
+        }
+
+        private static void GlobalAssertWriteHeading(
+            string expectedValue,
+            int? numberOfLineAppends,
+            string? headingUnderline,
+            Action writeToRoot)
+        {
+            using var monitor = new ConsoleTestMonitor();
+            var testValue = new StringBuilder($"{expectedValue}{Environment.NewLine}");
+            var underline = headingUnderline.IsNotNullOrEmpty()
+                ? ObjectExtensions.DefaultHeadingUnderline
+                : headingUnderline;
+
+            if (expectedValue.IsNotNullOrEmpty())
+            {
+                for (var i = 0; i < expectedValue.Length; i++)
+                {
+                    testValue.Append(underline);
+                }
+
+                testValue.Append(Environment.NewLine);
+            }
+
+            if (numberOfLineAppends.HasValue)
+            {
+                for (var i = 0; i < numberOfLineAppends; i++)
+                {
+                    testValue.Append(Environment.NewLine);
+                }
+            }
+
+            writeToRoot();
+
+            Assert.AreEqual(testValue.ToString(), monitor.GetOutputText());
         }
     }
 }

--- a/src/.net/Tenjin.Tests/ExtensionsTests/StringExtensionsTests.cs
+++ b/src/.net/Tenjin.Tests/ExtensionsTests/StringExtensionsTests.cs
@@ -19,6 +19,19 @@ namespace Tenjin.Tests.ExtensionsTests
             Assert.AreEqual(expectedOutput, value.IsNotNullOrEmpty());
         }
 
+        [TestCase(null, true)]
+        [TestCase("", true)]
+        [TestCase(" ", false)]
+        [TestCase("1", false)]
+        [TestCase("12", false)]
+        [TestCase("123", false)]
+        public void IsNullOrEmpty_WhenGivenAnInput_MatchesExpectedOutput(
+            string? value,
+            bool expectedOutput)
+        {
+            Assert.AreEqual(expectedOutput, value.IsNullOrEmpty());
+        }
+
         [TestCase(null, null, true)]
         [TestCase("", "", true)]
         [TestCase("123", "123", true)]

--- a/src/.net/Tenjin.Tests/Models/Console/ConsoleObject.cs
+++ b/src/.net/Tenjin.Tests/Models/Console/ConsoleObject.cs
@@ -1,0 +1,22 @@
+﻿namespace Tenjin.Tests.Models.Console
+{
+    public class ConsoleObject
+    {
+        public static string GetOutputText(string name)
+        {
+            return $"Hello tests, my name is {name}";
+        }
+
+        public string Name { get; }
+
+        public ConsoleObject(string name)
+        {
+            Name = name;
+        }
+
+        public override string ToString()
+        {
+            return GetOutputText(Name);
+        }
+    }
+}

--- a/src/.net/Tenjin.Tests/Services/ConsoleTestMonitor.cs
+++ b/src/.net/Tenjin.Tests/Services/ConsoleTestMonitor.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.IO;
+using System.Text;
+
+namespace Tenjin.Tests.Services
+{
+    public class ConsoleTestMonitor : IDisposable
+    {
+        private bool _disposed;
+
+        private readonly StringBuilder _output;
+        private readonly TextWriter _originalConsoleStream;
+
+        public ConsoleTestMonitor()
+        {
+            _output = new StringBuilder();
+            _originalConsoleStream = Console.Out;
+
+            var writer = new StringWriter(_output);
+
+            Console.SetOut(writer);
+        }
+
+        public string GetOutputText()
+        {
+            var result = _output.ToString();
+
+            Dispose();
+
+            return result;
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            Console.SetOut(_originalConsoleStream);
+        }
+    }
+}

--- a/src/.net/Tenjin.sln.DotSettings
+++ b/src/.net/Tenjin.sln.DotSettings
@@ -1,2 +1,4 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Formattable/@EntryIndexedValue">True</s:Boolean>
+	
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Tenjin/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/src/.net/Tenjin/Extensions/ObjectExtensions.cs
+++ b/src/.net/Tenjin/Extensions/ObjectExtensions.cs
@@ -1,9 +1,12 @@
-﻿using System.Linq;
+﻿using System;
+using System.Linq;
 
 namespace Tenjin.Extensions
 {
     public static class ObjectExtensions
     {
+        public const string DefaultHeadingUnderline = "=";
+
         public static bool DoesNotEqual<TObject>(this TObject? left, TObject? right)
         {
             return !Equals(left, right);
@@ -27,6 +30,122 @@ namespace Tenjin.Extensions
         public static bool DoesNotEqualAny(this object? root, params object?[] objects)
         {
             return objects.Any(obj => !Equals(root, obj));
+        }
+
+        public static void WriteLines(this object? _, int numberOfWriteLines = 1)
+        {
+            InternalWriteLines(numberOfWriteLines);
+        }
+
+        public static void Write(
+            this IFormattable? root,
+            string? format = null,
+            IFormatProvider? formatProvider = null)
+        {
+            var output = root?.ToString(format, formatProvider) ?? string.Empty;
+
+            Console.Write(output);
+        }
+
+        public static void WriteLine(
+            this IFormattable? root,
+            string? format = null,
+            IFormatProvider? formatProvider = null,
+            int? writeLineAppends = null)
+        {
+            var output = root?.ToString(format, formatProvider) ?? string.Empty;
+
+            InternalWriteLine(output, writeLineAppends);
+        }
+
+        public static void Write(this object? root)
+        {
+            var output = root?.ToString() ?? string.Empty;
+
+            Console.Write(output);
+        }
+
+        public static void WriteLine(
+            this object? root,
+            int? writeLineAppends = null)
+        {
+            var output = root?.ToString() ?? string.Empty;
+
+            InternalWriteLine(output, writeLineAppends);
+        }
+
+        public static void WriteHeading(
+            this object? root,
+            string? headingUnderline,
+            int? writeLineAppends = null)
+        {
+            var output = root?.ToString() ?? string.Empty;
+            var underline = headingUnderline.IsNotNullOrEmpty()
+                ? DefaultHeadingUnderline
+                : headingUnderline;
+
+            InternalWriteHeading(output, underline, writeLineAppends);
+        }
+
+        public static void WriteHeading(
+            this IFormattable? root,
+            string? format = null,
+            IFormatProvider? formatProvider = null,
+            string? headingUnderline = null,
+            int? writeLineAppends = null)
+        {
+            var output = root?.ToString(format, formatProvider) ?? string.Empty;
+            var underline = headingUnderline.IsNotNullOrEmpty()
+                ? DefaultHeadingUnderline
+                : headingUnderline;
+
+            InternalWriteHeading(output, underline, writeLineAppends);
+        }
+
+        private static void InternalWriteHeading(
+            string? value,
+            string headingUnderline,
+            int? writeLineAppends)
+        {
+            Console.WriteLine(value);
+
+            InternalWriteHeadingUnderline(value, headingUnderline);
+            InternalWriteLines(writeLineAppends);
+        }
+
+        private static void InternalWriteHeadingUnderline(string? value, string headingUnderline)
+        {
+            if (value.IsNullOrEmpty())
+            {
+                return;
+            }
+
+            for (var i = 0; i < value.Length; i++)
+            {
+                Console.Write(headingUnderline);
+            }
+
+            Console.WriteLine();
+        }
+
+        private static void InternalWriteLine(string? value, int? writeLineAppends = null)
+        {
+            Console.WriteLine(value);
+
+            InternalWriteLines(writeLineAppends);
+        }
+
+        public static void InternalWriteLines(int? numberOfWriteLines)
+        {
+            if (numberOfWriteLines == null)
+            {
+                return;
+            }
+
+            for (var i = 0; i < numberOfWriteLines; i++)
+            {
+                Console.WriteLine();
+            }
         }
     }
 }

--- a/src/.net/Tenjin/Extensions/StringExtensions.cs
+++ b/src/.net/Tenjin/Extensions/StringExtensions.cs
@@ -5,6 +5,11 @@ namespace Tenjin.Extensions
 {
     public static class StringExtensions
     {
+        public static bool IsNullOrEmpty([NotNullWhen(false)] this string? value)
+        {
+            return string.IsNullOrEmpty(value);
+        }
+
         public static bool IsNotNullOrEmpty([NotNullWhen(false)] this string? value)
         {
             return !string.IsNullOrEmpty(value);


### PR DESCRIPTION
20220429 - Added extensions for objects to print the .ToString method of an object to the console, with unit tests.
20220429 - Added the extension method IsNullOrEmpty for String classes with unit tests.